### PR TITLE
Remove duplicate docc-plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,3 @@ let package = Package(
         ),
     ]
 )
-// Add the documentation compiler plugin if possible
-#if swift(>=5.6)
-    package.dependencies.append(
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
-    )
-#endif


### PR DESCRIPTION
Our nightly flagged this:

https://github.com/SwiftPackageIndex/PackageList/runs/6749394625?check_suite_focus=true#step:4:232